### PR TITLE
Upgrade to rustc 1.0.0-dev (ea8b82e90 2015-03-17) (built 2015-03-18).

### DIFF
--- a/src/tokenizer/interface.rs
+++ b/src/tokenizer/interface.rs
@@ -13,7 +13,6 @@ use core::clone::Clone;
 use tokenizer::states;
 
 use collections::vec::Vec;
-use collections::slice::SliceExt;
 use collections::string::String;
 use std::borrow::Cow;
 use std::marker::Send;

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -39,9 +39,7 @@ use core::mem::replace;
 use core::default::Default;
 use alloc::boxed::Box;
 use collections::vec::Vec;
-use collections::slice::SliceExt;
 use collections::string::{String, ToString};
-use collections::str::StrExt;
 use std::borrow::Cow::{self, Borrowed};
 use std::collections::BTreeMap;
 

--- a/src/util/str.rs
+++ b/src/util/str.rs
@@ -14,7 +14,6 @@ use collections::string::String;
 use core::fmt::Debug;
 
 pub fn to_escaped_string<T: Debug>(x: &T) -> String {
-    use collections::str::StrExt;
     use core::fmt::Write;
 
     // FIXME: don't allocate twice


### PR DESCRIPTION
Don't use removed traits. Tests still fails with ICE.
